### PR TITLE
Error checks on the addresses supplied by gdb.

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -112,7 +112,7 @@ bool nrf51_probe(target *t)
 	case 0x0020: /* nRF51822 (rev 1) CEAA BA */
 	case 0x0024: /* nRF51422 (rev 1) QFAA C0 */
 	case 0x002A: /* nRF51822 (rev 2) QFAA FA0 */
-	case 0x004A: /* nRF51822 (rev 3) QFAA G1 */ 			
+	case 0x004A: /* nRF51822 (rev 3) QFAA G1 */
 	case 0x002D: /* nRF51422 (rev 2) QFAA DAA */
 	case 0x002E: /* nRF51422 (rev 2) QFAA E0 */
 	case 0x002F: /* nRF51822 (rev 1) CEAA B0 */
@@ -129,7 +129,7 @@ bool nrf51_probe(target *t)
 	case 0x0079: /* nRF51822 (rev 3) CEAA E0 */
 	case 0x007A: /* nRF51422 (rev 3) CEAA C0 */
 	case 0x008F: /* nRF51822 (rev 3) QFAA H1 See https://devzone.nordicsemi.com/question/97769/can-someone-conform-the-config-id-code-for-the-nrf51822qfaah1/ */
-	case 0x00D1: /* nRF51822 (rev 3) QFAA H2 */		
+	case 0x00D1: /* nRF51822 (rev 3) QFAA H2 */
 		t->driver = "Nordic nRF51";
 		target_add_ram(t, 0x20000000, 0x4000);
 		nrf51_add_flash(t, 0x00000000, 0x40000, NRF51_PAGE_SIZE);
@@ -208,6 +208,9 @@ static int nrf51_flash_erase(struct target_flash *f, target_addr addr, size_t le
 		while (target_mem_read32(t, NRF51_NVMC_READY) == 0)
 			if(target_check_error(t))
 				return -1;
+
+		if (len < f->blocksize)
+			return -1; // aligment problem?
 
 		addr += f->blocksize;
 		len -= f->blocksize;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -199,6 +199,9 @@ int target_flash_erase(target *t, target_addr addr, size_t len)
 	int ret = 0;
 	while (len) {
 		struct target_flash *f = flash_for_addr(t, addr);
+		if (!f)
+			return -1;
+
 		size_t tmplen = MIN(len, f->length - (addr % f->length));
 		ret |= f->erase(f, addr, tmplen);
 		addr += tmplen;
@@ -213,6 +216,9 @@ int target_flash_write(target *t,
 	int ret = 0;
 	while (len) {
 		struct target_flash *f = flash_for_addr(t, dest);
+		if (!f)
+			return -1;
+
 		size_t tmptarget = MIN(dest + len, f->start + f->length);
 		size_t tmplen = tmptarget - dest;
 		if (f->align > 1) {
@@ -563,4 +569,3 @@ int tc_system(target *t, target_addr cmd, size_t cmdlen)
 	}
 	return t->tc->system(t->tc, cmd, cmdlen);
 }
-


### PR DESCRIPTION
This is closing the barn door after the horse has escaped, but it would have saved some debugging time to have these error checks in place.

Also, it is more civilized to return an error on malformed input than to crash (null pointer dereference) or loop forever (while(len) after len wraps below zero.)